### PR TITLE
✨ Add sale type selection feature to fanza_sale command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 from playwright_scraper import FanzaScraper  # Playwright版を使用
 from config import (
     DISCORD_TOKEN, COMMAND_PREFIX, RATE_LIMIT_DURATION,
-    LOG_LEVEL, LOG_FORMAT
+    LOG_LEVEL, LOG_FORMAT, SALE_TYPES, get_sale_url
 )
 
 # ログ設定
@@ -282,16 +282,24 @@ async def fanza_sale(ctx):
 # スラッシュコマンド定義
 @bot.tree.command(name="fanza_sale", description="🎬 セール中の高評価AV作品(評価4.0以上)を表示")
 @app_commands.describe(
-    mode="表示モード: 評価順（デフォルト）、ランダム、リスト形式"
+    mode="表示モード: 評価順（デフォルト）、ランダム、リスト形式",
+    sale_type="セールタイプ: 全て、期間限定、割引、日替わり、激安"
 )
 @app_commands.choices(
     mode=[
         app_commands.Choice(name="🏆 評価順（デフォルト）", value="rating"),
         app_commands.Choice(name="🎲 ランダム", value="random"),
         app_commands.Choice(name="📋 リスト形式", value="list"),
+    ],
+    sale_type=[
+        app_commands.Choice(name="🎯 全てのセール", value="all"),
+        app_commands.Choice(name="⏰ 期間限定セール", value="limited"),
+        app_commands.Choice(name="💸 割引セール (20-70% OFF)", value="percent"),
+        app_commands.Choice(name="📅 日替わりセール", value="daily"),
+        app_commands.Choice(name="💴 激安セール (10円/100円)", value="cheap"),
     ]
 )
-async def slash_fanza_sale(interaction: discord.Interaction, mode: str = "rating"):
+async def slash_fanza_sale(interaction: discord.Interaction, mode: str = "rating", sale_type: str = "all"):
     """スラッシュコマンド版: FANZAのセール中高評価作品を表示"""
     
     # NSFWチェック
@@ -306,12 +314,18 @@ async def slash_fanza_sale(interaction: discord.Interaction, mode: str = "rating
         # 処理中メッセージ（defer で3秒の猶予を確保）
         await interaction.response.defer()
         
+        # セールタイプに応じたURLを生成
+        url = get_sale_url(sale_type)
+        
         # 商品情報を取得
-        products = await scraper.get_high_rated_products()
+        products = await scraper.get_high_rated_products(url=url, sale_type=sale_type)
         
         if not products:
             await interaction.followup.send("❌ 現在、評価4.0以上の商品が見つかりませんでした。", ephemeral=True)
             return
+        
+        # セールタイプの表示名を取得
+        sale_type_name = SALE_TYPES.get(sale_type, {}).get("name", "🎯 全てのセール")
         
         # モードに応じて処理
         import random
@@ -319,15 +333,15 @@ async def slash_fanza_sale(interaction: discord.Interaction, mode: str = "rating
         if mode == "random":
             # ランダムモード: 商品をシャッフルして5件選択
             products = random.sample(products, min(5, len(products)))
-            title = "🎲 FANZAセール ランダム作品"
+            title = f"🎲 FANZAセール ランダム作品 - {sale_type_name}"
             description = f"ランダムに選ばれた高評価作品です (5件)"
         elif mode == "list":
             # リストモード: 簡易表示
-            title = "📋 FANZAセール 作品リスト"
+            title = f"📋 FANZAセール 作品リスト - {sale_type_name}"
             description = f"現在セール中の高評価作品一覧 ({len(products)}件)"
         else:
             # 評価順モード（デフォルト）- 最初の5件のみ表示
-            title = "🎬 FANZAセール 高評価作品TOP5"
+            title = f"🎬 FANZAセール 高評価作品TOP5 - {sale_type_name}"
             description = f"現在セール中の評価4.0以上の作品です (表示: 5件 / 全{len(products)}件)"
             products = products[:5]  # 評価順とランダムモードは5件に制限
         
@@ -389,7 +403,7 @@ async def slash_help(interaction: discord.Interaction):
     )
     embed.add_field(
         name="🎯 `/fanza_sale`",
-        value="セール中の高評価作品（評価4.0以上）を最大5件表示\n**推奨コマンド**\n\n**オプション:**\n• 🏆 評価順（デフォルト）\n• 🎲 ランダム\n• 📋 リスト形式",
+        value="セール中の高評価作品（評価4.0以上）を最大5件表示\n**推奨コマンド**\n\n**表示モード:**\n• 🏆 評価順（デフォルト）\n• 🎲 ランダム\n• 📋 リスト形式\n\n**セールタイプ:**\n• 🎯 全て（デフォルト）\n• ⏰ 期間限定\n• 💸 割引セール\n• 📅 日替わり\n• 💴 激安セール",
         inline=True
     )
     embed.add_field(

--- a/config.py
+++ b/config.py
@@ -8,7 +8,43 @@ DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 COMMAND_PREFIX = "!"
 
 # FANZAスクレイピング設定
-FANZA_SALE_URL = "https://video.dmm.co.jp/av/list/?key=%E6%9C%9F%E9%96%93%E9%99%90%E5%AE%9A%E3%82%BB%E3%83%BC%E3%83%AB|20%EF%BC%85OFF|30%EF%BC%85OFF|50%EF%BC%85OFF|70%EF%BC%85OFF|%E6%97%A5%E6%9B%BF%E3%82%8F%E3%82%8A%E3%82%BB%E3%83%BC%E3%83%AB|10%E5%86%86%E3%82%BB%E3%83%BC%E3%83%AB|100%E5%86%86%E3%82%BB%E3%83%BC%E3%83%AB&sort=review_rank"
+FANZA_BASE_URL = "https://video.dmm.co.jp/av/list/"
+FANZA_SORT = "review_rank"
+
+# セールタイプの定義
+SALE_TYPES = {
+    "all": {
+        "name": "🎯 全てのセール",
+        "keys": ["期間限定セール", "20％OFF", "30％OFF", "50％OFF", "70％OFF", "日替わりセール", "10円セール", "100円セール"]
+    },
+    "limited": {
+        "name": "⏰ 期間限定セール",
+        "keys": ["期間限定セール"]
+    },
+    "percent": {
+        "name": "💸 割引セール (20-70% OFF)",
+        "keys": ["20％OFF", "30％OFF", "50％OFF", "70％OFF"]
+    },
+    "daily": {
+        "name": "📅 日替わりセール",
+        "keys": ["日替わりセール"]
+    },
+    "cheap": {
+        "name": "💴 激安セール (10円/100円)",
+        "keys": ["10円セール", "100円セール"]
+    }
+}
+
+# デフォルトのセールURL（全てのセール）
+FANZA_SALE_URL = f"{FANZA_BASE_URL}?key={'|'.join(SALE_TYPES['all']['keys'])}&sort={FANZA_SORT}"
+
+def get_sale_url(sale_type: str = "all") -> str:
+    """セールタイプに応じたURLを生成"""
+    if sale_type not in SALE_TYPES:
+        sale_type = "all"
+    
+    keys = SALE_TYPES[sale_type]["keys"]
+    return f"{FANZA_BASE_URL}?key={'|'.join(keys)}&sort={FANZA_SORT}"
 MIN_RATING = 4.0
 MAX_ITEMS = 50  # キャッシュする最大商品数（10ページ × 5件）
 # 表示設定


### PR DESCRIPTION
## Summary

• セールタイプ選択機能をfanza_saleコマンドに追加
• 5つの異なるセールカテゴリから選択可能に

## Changes Made

### 📝 Configuration Updates
- `SALE_TYPES`設定を追加（5つのセールカテゴリ定義）
- `get_sale_url()`関数を実装（動的URL生成）

### 🤖 Bot Command Enhancements  
- スラッシュコマンドに`sale_type`パラメータを追加
- ドロップダウンメニューでセールタイプ選択可能
- 表示タイトルに選択されたセールタイプを表示
- ヘルプドキュメントを新しいオプションで更新

### ⚡ Scraper Improvements
- カスタムURL対応をスクレイパーに実装
- セールタイプ別キャッシュシステム導入
- 効率的なデータ取得のための最適化

## Available Sale Types

 < /dev/null |  セールタイプ | 説明 | キーワード |
|------------|------|----------|
| 🎯 全てのセール | すべてのセール対象作品 | すべてのセールキーワード |
| ⏰ 期間限定セール | 期間限定販売作品 | 期間限定セール |
| 💸 割引セール | 20-70%の割引作品 | 20％OFF〜70％OFF |
| 📅 日替わりセール | 日替わり特価作品 | 日替わりセール |
| 💴 激安セール | 超特価作品 | 10円セール, 100円セール |

## Technical Implementation

- **Dynamic URL Generation**: セールタイプに応じたクエリパラメータ自動生成
- **Per-Type Caching**: セールタイプ別の独立したキャッシュシステム
- **User-Friendly Interface**: ドロップダウンメニューによる直感的な選択

## Test Plan

- [x] URL生成機能のテスト
- [x] セールタイプ別のスクレイピング動作確認
- [x] キャッシュシステムの動作確認
- [x] ボットのインポートと設定確認
- [ ] 実際のDiscordサーバーでのコマンド動作テスト

🤖 Generated with [Claude Code](https://claude.ai/code)